### PR TITLE
Feat/add comments to feedback session

### DIFF
--- a/app/controllers/api/internal/comments_controller.rb
+++ b/app/controllers/api/internal/comments_controller.rb
@@ -1,0 +1,17 @@
+class Api::Internal::CommentsController < Api::Internal::BaseController
+  before_action :authenticate_user!
+
+  def create
+    respond_with feedback_session.comments.create!(permitted_params)
+  end
+
+  private
+
+  def permitted_params
+    params.require(:comment).permit(:body)
+  end
+
+  def feedback_session
+    @feedback_session ||= FeedbackSession.for_user(current_user).find(params[:feedback_session_id])
+  end
+end

--- a/app/controllers/app/comments_controller.rb
+++ b/app/controllers/app/comments_controller.rb
@@ -1,0 +1,11 @@
+class App::CommentsController < App::BaseController
+  def new
+    @feedback_session = feedback_session
+  end
+
+  private
+
+  def feedback_session
+    @feedback_session ||= FeedbackSession.find(params[:feedback_session_id])
+  end
+end

--- a/app/controllers/app/feedback_sessions_controller.rb
+++ b/app/controllers/app/feedback_sessions_controller.rb
@@ -2,4 +2,15 @@ class App::FeedbackSessionsController < App::BaseController
   def index
     @provider_sessions = current_user.providers.includes(:provider, :receiver)
   end
+
+  def show
+    @feedback_session = feedback_session
+    @comments = feedback_session.comments
+  end
+
+  private
+
+  def feedback_session
+    @feedback_session ||= FeedbackSession.find(params[:id])
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :feedback_session
 
+  validates :body, presence: true
   validates :feedback_session_id, presence: true
 end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,20 @@
+class Comment < ApplicationRecord
+  belongs_to :feedback_session
+
+  validates :feedback_session_id, presence: true
+end
+
+# == Schema Information
+#
+# Table name: comments
+#
+#  id                  :bigint(8)        not null, primary key
+#  feedback_session_id :bigint(8)
+#  body                :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_comments_on_feedback_session_id  (feedback_session_id)
+#

--- a/app/models/feedback_session.rb
+++ b/app/models/feedback_session.rb
@@ -1,6 +1,7 @@
 class FeedbackSession < ApplicationRecord
   belongs_to :provider, class_name: 'User'
   belongs_to :receiver, class_name: 'User'
+  has_many :comments, dependent: :destroy
 
   scope :for_user, ->(user) { where(provider: user).or(where(receiver: user)) }
 

--- a/app/serializers/api/internal/comment_serializer.rb
+++ b/app/serializers/api/internal/comment_serializer.rb
@@ -1,0 +1,11 @@
+class Api::Internal::CommentSerializer < ActiveModel::Serializer
+  type :comment
+
+  attributes(
+    :id,
+    :feedback_session_id,
+    :body,
+    :created_at,
+    :updated_at
+  )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,17 @@ Rails.application.routes.draw do
   mount CoverImageUploader.derivation_endpoint => "/derivations/cover_image"
   mount Sidekiq::Web => '/queue'
 
+  scope module: :app, defaults: { format: :html } do
+    resources :feedback_sessions, only: [:show] do
+      resources :comments, only: [:new]
+    end
+  end
+
   namespace :api, defaults: { format: :json } do
     namespace :internal do
-      resources :feedback_sessions, only: [:index]
+      resources :feedback_sessions, only: [:index] do
+        resources :comments, only: [:create]
+      end
     end
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define()

--- a/db/migrate/20221226160633_create_comments.rb
+++ b/db/migrate/20221226160633_create_comments.rb
@@ -1,0 +1,9 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.references :feedback_session
+      t.text :body
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_10_180905) do
+ActiveRecord::Schema.define(version: 2022_12_26_160633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,14 @@ ActiveRecord::Schema.define(version: 2022_11_10_180905) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.bigint "feedback_session_id"
+    t.text "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["feedback_session_id"], name: "index_comments_on_feedback_session_id"
   end
 
   create_table "feedback_sessions", force: :cascade do |t|

--- a/lib/fake_data_loader.rb
+++ b/lib/fake_data_loader.rb
@@ -33,6 +33,7 @@ module FakeDataLoader
     load_admin
     load_users
     load_sessions
+    load_comments
   end
 
   def self.load_admin
@@ -53,6 +54,12 @@ module FakeDataLoader
 
       puts "user: #{user.email} - password: #{USER_PASSWORD}"
     end
+    create(
+      :user,
+      name: 'Ale',
+      email: 'ale@test.com',
+      password: '123123'
+    )
   end
 
   def self.load_sessions
@@ -62,6 +69,18 @@ module FakeDataLoader
           :feedback_session,
           provider: user,
           receiver: User.where.not(id: user.id).sample
+        )
+      end
+    end
+  end
+
+  def self.load_comments
+    FeedbackSession.all.each do |feedback_session|
+      2.times do
+        create(
+          :comment,
+          feedback_session_id: feedback_session.id,
+          body: Faker::Lorem.sentence(word_count: 3)
         )
       end
     end

--- a/spec/controllers/app/comments_controller_spec.rb
+++ b/spec/controllers/app/comments_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe App::CommentsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:feedback_session) { create(:feedback_session, receiver: user) }
+
+  describe "GET #new" do
+    before do
+      sign_in(user)
+      perform
+    end
+
+    def perform
+      get :new, params: { feedback_session_id: feedback_session.id }
+    end
+
+    it 'returns a success code' do
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/controllers/app/feedback_sessions_controller_spec.rb
+++ b/spec/controllers/app/feedback_sessions_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe App::FeedbackSessionsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:feedback_session) { create(:feedback_session, receiver: user) }
+
+  describe "GET #index" do
+    before do
+      sign_in(user)
+      perform
+    end
+
+    def perform
+      get :index
+    end
+
+    it 'returns a success code' do
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "GET #show" do
+    before do
+      sign_in(user)
+      perform
+    end
+
+    def perform
+      get :show, params: { id: feedback_session.id }
+    end
+
+    it 'returns a success code' do
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :comment do
+    feedback_session { create(:feedback_session) }
+    body { Faker::Lorem.sentence }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Comment, type: :model do
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:feedback_session_id) }
+    it { is_expected.to validate_presence_of(:body) }
   end
 
   describe 'Associations' do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  it 'has a valid factory' do
+    expect(build(:comment)).to be_valid
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:feedback_session_id) }
+  end
+
+  describe 'Associations' do
+    subject(:comment) { build(:comment) }
+
+    it { expect(comment).to belong_to(:feedback_session) }
+  end
+end

--- a/spec/requests/api/internal/comments_spec.rb
+++ b/spec/requests/api/internal/comments_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Internal::CommentsControllers', type: :request do
+  describe 'POST /create' do
+    let(:user) { create(:user) }
+    let(:feedback_session) { create(:feedback_session, provider:user) }
+
+
+    let(:params) do
+      {
+        comment: {
+          body: "cualquier cosa"
+        }
+      }
+    end
+
+    let(:attributes) do
+      JSON.parse(response.body)['comment'].symbolize_keys
+    end
+
+    def perform
+      post "/api/internal/feedback_sessions/#{feedback_session.id}/comments", params: params
+    end
+
+    before do
+      sign_in(user)
+      perform
+    end
+
+    it { expect {perform}.to change { Comment.count }.by(1) }
+    it { expect(response.status).to eq(201) }
+  end
+end


### PR DESCRIPTION
### Contexto
Se tienen sesiones de feedback las cuales tienen un usuario proveedor de la sesión y un usuario receptor de la sesión. En la página principal se puede visualizar una lista con todas las sesiones a las cuales el usuario logeado ha entregado/recibido feedback. 
Para estas sesiones se quiere construir una vista que permita al usuario proveedor de la sesión añadir comentarios a la misma y otra vista que permita ver los detalles de la sesión con los comentarios creados.
### Qué se esta haciendo
Se están realizando los cambios y agregaciones necesarias en el back-end. Esto considera 
- El modelo de comment con:
  - Relaciones
  - validaciones
  - tests
- Los controladores de api y app con:
  - tests
- Las rutas asociadas a las vistas de los comentarios
- fake data de los comentarios
​
#### En particular hay que revisar
​
-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
Vista de sesiones de feedback
![image](https://user-images.githubusercontent.com/62600949/210573120-45c90626-109a-4636-a4ff-e0866646194f.png)
Vista de detalles de la sesión de feedback
![image](https://user-images.githubusercontent.com/62600949/210573344-a3a9135a-c30f-45b3-9ac9-e48c48ee350f.png)
Vista de añadir comentario
![image](https://user-images.githubusercontent.com/62600949/210573437-9c6d734f-fe45-4b27-b705-7197a03fecda.png)
